### PR TITLE
Taking Priors Seriously

### DIFF
--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -386,7 +386,7 @@ function exp_smoothness_prior(basis; al = 1.0, an = 1.0)
       if length(bb) == 0; return 1.0; end
       nn = [ b.n for b in bb]
       ll = [ b.l for b in bb]
-      return exp(al * sum(ll) + an * sum(nn.^2))
+      return exp(al * sum(ll) + an * sum(nn))
    end
 
    return Diagonal(_reg.(_get_nnll(basis)))

--- a/test/test_priors.jl
+++ b/test/test_priors.jl
@@ -1,0 +1,13 @@
+
+using ACE1x
+
+model = acemodel(; elements = [:Al, :Ti], 
+                   order = 2, totaldegree = 8 )
+
+basis = model.basis
+spec = ACE1x._get_nnll(basis)
+
+palg = algebraic_smoothness_prior(basis; p = 2).diag
+pexp = exp_smoothness_prior(basis; al = 1.0, an = 1.5).diag
+pgauss = gaussian_smoothness_prior(basis; σl = 2.2, σn = 1.5).diag
+


### PR DESCRIPTION
@JPDarby  -- This PR is for us to collaborate on implementing a general smoothness priors framework that both of us (and other users) will be happy with. So far I've exposed everything we need from ACE1.jl in ACE1x.jl and I've started porting the functionality we put together in your scripts into ACE1x.jl. 

- I have less time than I thought (hence also my delay - apologies for that) and I'd be very grateful if you would be willing to help me test this: please look at `defaults.jl` and at `test_priors.jl`. You may wish to move the priors code into a new `smoothness_priors.jl` file to separate it from the defaults. 
- After getting a first quick and dirty version up and running and test it, we can merge and tag it.
- I would like us to briefly think about how the prior for each body-order N should be rescaled!!! I think this is a point we neglected so far and which might make a big difference!
- When we are done with that, I would like to have a chat with you and with Chuck about making the prior parameters learnable during the BLR. 

Some of this can go into future PRs. I prefer to make quick changes, test, commit, tag. 