### PR TITLE
Cleanup priors - Update default

### DIFF
--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -356,7 +356,20 @@ export algebraic_smoothness_prior,
        exp_smoothness_prior
 
 
-function smoothness_prior(basis; p = 2, wL = 1.0)
+function smoothness_prior(basis, typ = :algebraic; kwargs...)
+   if typ == :algebraic
+      return algebraic_smoothness_prior(basis; kwargs...)
+   elseif typ == :gaussian
+      return gaussian_smoothness_prior(basis; kwargs...)
+   elseif typ == :exp
+      return exp_smoothness_prior(basis; kwargs...)
+   end
+   error("Unknown smoothness prior type: $typ")
+end
+
+
+
+function algebraic_smoothness_prior(basis; p = 4, wL = 1.0) 
    d = Float64[]
    for B in basis.BB
       if B isa ACE1.RPI.RPIBasis
@@ -367,11 +380,6 @@ function smoothness_prior(basis; p = 2, wL = 1.0)
    end
    return Diagonal(1 .+ d)
 end
-
-
-
-algebraic_smoothness_prior(basis; kwargs...) = 
-      smoothness_prior(basis; kwargs...)
 
 
 _get_nnll(basis::ACE1.RPI.RPIBasis) = 


### PR DESCRIPTION
@wcwitt and @JPDarby  -- this is mostly for your information: this PR does three things 

- It renames the `smoothness_prior` -> `algebraic_prior` 
- changes the default algebraic parameter to 4
- and implementes a new `smoothness_prior` function as follows: 
```julia
function smoothness_prior(basis, typ = :algebraic; kwargs...)
   if typ == :algebraic
      return algebraic_smoothness_prior(basis; kwargs...)
   elseif typ == :gaussian
      return gaussian_smoothness_prior(basis; kwargs...)
   elseif typ == :exp
      return exp_smoothness_prior(basis; kwargs...)
   end
   error("Unknown smoothness prior type: $typ")
end
```
This should make parameter scanning a little easier. This maintains the default bevahiour of choosing the algebraic prior (but with `p = 4` now.