### PR TITLE
bugfixes for element dependent cutoffs

### DIFF
--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -177,7 +177,11 @@ function _transform(kwargs; transform = kwargs[:transform])
          q = transform[3]
          r0 = _get_all_r0(kwargs)
          rcut = _get_all_rcut(kwargs)
-         cutoffs = Dict([ (s1, s2) => (0.0, rcut[(s1, s2)]) for s1 in elements, s2 in elements]...)
+         if rcut isa Number
+            cutoffs = nothing
+         else
+            cutoffs = Dict([ (s1, s2) => (0.0, rcut[(s1, s2)]) for s1 in elements, s2 in elements]...)
+         end
          rcut = maximum(values(rcut))  # multitransform wants a single cutoff.
          
          if ( (length(transform) == 3) || 

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -177,13 +177,14 @@ function _transform(kwargs; transform = kwargs[:transform])
          q = transform[3]
          r0 = _get_all_r0(kwargs)
          rcut = _get_all_rcut(kwargs)
+         cutoffs = Dict([ (s1, s2) => (0.0, rcut[(s1, s2)]) for s1 in elements, s2 in elements]...)
          rcut = maximum(values(rcut))  # multitransform wants a single cutoff.
-
+         
          if ( (length(transform) == 3) || 
               (length(transform) == 4 && transform[end] == :free) )
             transforms = Dict([ (s1, s2) => agnesi_transform(r0[(s1, s2)], p, q)
                               for s1 in elements, s2 in elements]... )
-            trans_ace = multitransform(transforms; rin = 0.0, rcut = rcut)
+            trans_ace = multitransform(transforms; rin = 0.0, rcut = rcut, cutoffs=cutoffs)
             return trans_ace
 
          elseif length(transform) == 4
@@ -250,6 +251,8 @@ end
 function _pair_basis(kwargs)
    rbasis = kwargs[:pair_basis]
    elements = kwargs[:elements]
+   #elements has to be sorted becuase PolyPairBasis (see end of function) assumes sorted.
+   elements = [chemical_symbol(z) for z in JuLIP.Potentials.ZList(elements, static=true).list]
 
    if rbasis isa ACE1.ScalarBasis
       return rbasis

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -58,7 +58,9 @@ const _kw_defaults = Dict(:elements => nothing,
                           :pair_basis => :legendre,
                           :pair_envelope => (:r, 2),
                           #
-                          :Eref => missing
+                          :Eref => missing,
+                          #temporary variable to specify whether using the variable cutoffs or not
+                          :variable_cutoffs => false,
                           )
 
 const _kw_aliases = Dict( :N => :order,
@@ -177,7 +179,7 @@ function _transform(kwargs; transform = kwargs[:transform])
          q = transform[3]
          r0 = _get_all_r0(kwargs)
          rcut = _get_all_rcut(kwargs)
-         if rcut isa Number
+         if rcut isa Number || ! kwargs[:variable_cutoffs]
             cutoffs = nothing
          else
             cutoffs = Dict([ (s1, s2) => (0.0, rcut[(s1, s2)]) for s1 in elements, s2 in elements]...)
@@ -256,7 +258,9 @@ function _pair_basis(kwargs)
    rbasis = kwargs[:pair_basis]
    elements = kwargs[:elements]
    #elements has to be sorted becuase PolyPairBasis (see end of function) assumes sorted.
-   elements = [chemical_symbol(z) for z in JuLIP.Potentials.ZList(elements, static=true).list]
+   if kwargs[:variable_cutoffs]
+      elements = [chemical_symbol(z) for z in JuLIP.Potentials.ZList(elements, static=true).list]
+   end
 
    if rbasis isa ACE1.ScalarBasis
       return rbasis


### PR DESCRIPTION
Linked to https://github.com/ACEsuit/ACE1.jl/pull/82

- passed element dependent cutoffs to multitransform so it doesn't just default to using the largest one
- sorted elements because PolyPairBasis seems to expect this